### PR TITLE
change the icon-pack to be fa, change the icon from link to globe

### DIFF
--- a/content/authors/mohamed-nabail/_index.md
+++ b/content/authors/mohamed-nabail/_index.md
@@ -38,8 +38,8 @@ education:
 #   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
 #   form "mailto:your-email@example.com" or "#contact" for contact widget.
 social:
-  - icon: link
-    icon_pack: fab
+  - icon: globe
+    icon_pack: fa
     link: https://www.mohamednabail.com/
   - icon: google-scholar
     icon_pack: ai


### PR DESCRIPTION
Link icon does not look as expected: 

Current: 
![current](https://github.com/user-attachments/assets/24220bb3-3d02-4110-a5d8-6f33bedf9756)

Changing the package to fa instead of fab: 
![package](https://github.com/user-attachments/assets/195be067-37d1-49eb-a822-09df8180ec27)


Changing the icon from link to globe:
![icon_package](https://github.com/user-attachments/assets/c0371ad5-8170-4738-9544-cdbb11ec3892)
